### PR TITLE
Add systemd-resolved DNS switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# test-codeks
-Kodeks
+# DNS Switcher
+
+This repository contains a small script for switching the DNS servers used by `systemd-resolved`.
+
+## Modes
+
+- **cloudflare** – sets DNS servers to `1.1.1.1` and `1.0.0.1`.
+- **google** – sets DNS servers to `8.8.8.8` and `8.8.4.4`.
+- **default** – removes custom DNS entries and reverts to the system default.
+
+## Usage
+
+```bash
+sudo ./dns-switcher.sh cloudflare
+sudo ./dns-switcher.sh google
+sudo ./dns-switcher.sh default
+```
+
+The script edits `/etc/systemd/resolved.conf` and restarts `systemd-resolved`,
+so it must be run with root privileges.

--- a/dns-switcher.sh
+++ b/dns-switcher.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# DNS switcher for systemd-resolved.
+# Modes: cloudflare, google, default.
+
+set -e
+
+usage() {
+    echo "Usage: $0 {cloudflare|google|default}" >&2
+    exit 1
+}
+
+if [ $# -ne 1 ]; then
+    usage
+fi
+
+MODE="$1"
+CONF="/etc/systemd/resolved.conf"
+
+apply_dns() {
+    local dns="$1"
+    if [ ! -w "$CONF" ]; then
+        echo "This script requires root permissions." >&2
+        exit 1
+    fi
+    # Remove existing DNS= lines and append new one if provided.
+    sudo sed -i '/^DNS=/d' "$CONF"
+    if [ -n "$dns" ]; then
+        echo "DNS=$dns" | sudo tee -a "$CONF" >/dev/null
+    fi
+    sudo systemctl restart systemd-resolved
+}
+
+case "$MODE" in
+    cloudflare)
+        apply_dns "1.1.1.1 1.0.0.1"
+        ;;
+    google)
+        apply_dns "8.8.8.8 8.8.4.4"
+        ;;
+    default)
+        apply_dns ""
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+echo "DNS switched to $MODE" 


### PR DESCRIPTION
## Summary
- add a bash script to toggle systemd-resolved DNS between Cloudflare, Google, and the default configuration
- document script usage in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68623faab31c832ba483ea4742446dab